### PR TITLE
chore: define base node engine support to v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,5 +43,7 @@
     "decentralized",
     "identity"
   ],
-  "author": "Decentralized Identity Foundation"
+  "author": "Decentralized Identity Foundation",
+  "engines" : { "node" : ">=0.12" },
+  "engineStrict": true
 }


### PR DESCRIPTION
This is necessary because node.js <V12 doesn't support usage of globalThis and throws an error. If someone wished to use this library with a version of node below V12 they'd need to remove support for globalThis.