### PR TITLE
fix: pass reveal public key to SDK when updating DID

### DIFF
--- a/ion.js/lib.js
+++ b/ion.js/lib.js
@@ -169,6 +169,7 @@ ION.DID = class {
         return RawIonSdk.IonRequest.createUpdateRequest({
           didSuffix: await this.getSuffix(),
           signer: options.signer || RawIonSdk.LocalSigner.create(op.previous.update.privateJwk),
+          updatePublicKey: op.previous.update.publicJwk,
           nextUpdatePublicKey: op.update.publicJwk,
           servicesToAdd: op.content?.addServices,
           idsOfServicesToRemove: op.content?.removeServices,
@@ -181,6 +182,7 @@ ION.DID = class {
         return RawIonSdk.IonRequest.createRecoverRequest({
           didSuffix: await this.getSuffix(),
           signer: options.signer || RawIonSdk.LocalSigner.create(op.previous.recovery.privateJwk),
+          recoveryPublicKey: op.previous.recovery.publicJwk,
           nextRecoveryPublicKey: op.recovery.publicJwk,
           nextUpdatePublicKey: op.update.publicJwk,
           document: op.content
@@ -190,6 +192,7 @@ ION.DID = class {
       case 'deactivate':
         return RawIonSdk.IonRequest.createDeactivateRequest({
           didSuffix: await this.getSuffix(),
+          recoveryPublicKey: op.previous.recovery.publicJwk,
           signer: options.signer || RawIonSdk.LocalSigner.create(op.previous.recovery.privateJwk)
         });
       break;


### PR DESCRIPTION
Hi,

I noticed that updating a DID doesn't work.
The reason is that the underlying SDK also expects the public key that needs to be revealed (update public key or recovery public key respectively).
https://github.com/decentralized-identity/ion-sdk/blob/a7603470b980688353eed03e1425382eb903bad8/lib/IonRequest.ts#L168-L177

I just added the missing lines in `generateRequest()` so that the required value is passed to the SDK.
