### PR TITLE
removes @transmute/did-key-p384

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@decentralized-identity/ion-sdk": "0.5.0",
         "@transmute/did-key-bls12381": "^0.2.1-unstable.42",
         "@transmute/did-key-ed25519": "^0.2.1-unstable.42",
-        "@transmute/did-key-p384": "^0.2.1-unstable.20",
         "@transmute/did-key-secp256k1": "^0.2.1-unstable.42",
         "@transmute/did-key-x25519": "^0.2.1-unstable.42",
         "@transmute/did-key.js": "^0.2.1-unstable.42",
@@ -693,20 +692,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@transmute/did-key-p384": {
-      "version": "0.2.1-unstable.20",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-p384/-/did-key-p384-0.2.1-unstable.20.tgz",
-      "integrity": "sha512-gbsuw835jSvKUfhgCx0XrvAQrE7pbL6rNy9hipZ4LVJRY3yPT59tDqnPCcP2EHfc7ihjtVKf8TMevxA9kb81QQ==",
-      "dependencies": {
-        "base64url": "^3.0.1",
-        "bs58": "^4.0.1",
-        "canonicalize": "^1.0.1",
-        "node-webcrypto-ossl": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@transmute/did-key-secp256k1": {
       "version": "0.2.1-unstable.42",
       "resolved": "https://registry.npmjs.org/@transmute/did-key-secp256k1/-/did-key-secp256k1-0.2.1-unstable.42.tgz",
@@ -1171,6 +1156,14 @@
       "dependencies": {
         "pvutils": "latest"
       },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/asn1js/node_modules/pvutils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+      "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ==",
       "engines": {
         "node": ">=6.0.0"
       }
@@ -2459,7 +2452,7 @@
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
       "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
-      "deprecated": "core-js@<3.4 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Please, upgrade your dependencies to the actual version of core-js.",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
       "dev": true,
       "hasInstallScript": true
     },
@@ -5371,7 +5364,9 @@
     "node_modules/nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/nanomatch": {
       "version": "1.2.13",
@@ -5566,31 +5561,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true
-    },
-    "node_modules/node-webcrypto-ossl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.1.2.tgz",
-      "integrity": "sha512-EkrrRUWW+2QrsZ8PZfPSaRlWg38WOv2/mZTcW0l2SbEYERJ0G3OkW6kBiTpzUtcM+2PBaspNRZPfpBvvLp0NTQ==",
-      "deprecated": "node-webcrypto-ossl has been deprecated. This module was created in 2015 because at the time the Node team did not feel the need to have two crypto interfaces and they already had one before WebCrypto was defined",
-      "hasInstallScript": true,
-      "dependencies": {
-        "mkdirp": "^1.0.4",
-        "nan": "^2.14.1",
-        "pvtsutils": "^1.0.11",
-        "tslib": "^2.0.1",
-        "webcrypto-core": "^1.1.6"
-      }
-    },
-    "node_modules/node-webcrypto-ossl/node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/nofilter": {
       "version": "1.0.4",
@@ -6277,14 +6247,6 @@
       "integrity": "sha512-Yfm9Dsk1zfEpOWCaJaHfqtNXAFWNNHMFSCLN6jTnhuCCBCC2nqge4sAgo7UrkRBoAAYIL8TN/6LlLoNfZD/b5A==",
       "dependencies": {
         "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/pvutils": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ==",
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/qs": {
@@ -8870,17 +8832,6 @@
         "canonicalize": "^1.0.1"
       }
     },
-    "@transmute/did-key-p384": {
-      "version": "0.2.1-unstable.20",
-      "resolved": "https://registry.npmjs.org/@transmute/did-key-p384/-/did-key-p384-0.2.1-unstable.20.tgz",
-      "integrity": "sha512-gbsuw835jSvKUfhgCx0XrvAQrE7pbL6rNy9hipZ4LVJRY3yPT59tDqnPCcP2EHfc7ihjtVKf8TMevxA9kb81QQ==",
-      "requires": {
-        "base64url": "^3.0.1",
-        "bs58": "^4.0.1",
-        "canonicalize": "^1.0.1",
-        "node-webcrypto-ossl": "^2.1.0"
-      }
-    },
     "@transmute/did-key-secp256k1": {
       "version": "0.2.1-unstable.42",
       "resolved": "https://registry.npmjs.org/@transmute/did-key-secp256k1/-/did-key-secp256k1-0.2.1-unstable.42.tgz",
@@ -9254,6 +9205,13 @@
       "integrity": "sha512-t9u0dU0rJN4ML+uxgN6VM2Z4H5jWIYm0w8LsZLzMJaQsgL3IJNbxHgmbWDvJAwspyHpDFuzUaUFh4c05UB4+6g==",
       "requires": {
         "pvutils": "latest"
+      },
+      "dependencies": {
+        "pvutils": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.3.tgz",
+          "integrity": "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="
+        }
       }
     },
     "assert": {
@@ -12672,7 +12630,9 @@
     "nan": {
       "version": "2.14.2",
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -12831,25 +12791,6 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
       "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
       "dev": true
-    },
-    "node-webcrypto-ossl": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/node-webcrypto-ossl/-/node-webcrypto-ossl-2.1.2.tgz",
-      "integrity": "sha512-EkrrRUWW+2QrsZ8PZfPSaRlWg38WOv2/mZTcW0l2SbEYERJ0G3OkW6kBiTpzUtcM+2PBaspNRZPfpBvvLp0NTQ==",
-      "requires": {
-        "mkdirp": "^1.0.4",
-        "nan": "^2.14.1",
-        "pvtsutils": "^1.0.11",
-        "tslib": "^2.0.1",
-        "webcrypto-core": "^1.1.6"
-      },
-      "dependencies": {
-        "mkdirp": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-          "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-        }
-      }
     },
     "nofilter": {
       "version": "1.0.4",
@@ -13410,11 +13351,6 @@
       "requires": {
         "tslib": "^2.1.0"
       }
-    },
-    "pvutils": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.0.17.tgz",
-      "integrity": "sha512-wLHYUQxWaXVQvKnwIDWFVKDJku9XDCvyhhxoq8dc5MFdIlRenyPI9eSfEtcvgHgD7FlvCyGAlWgOzRnZD99GZQ=="
     },
     "qs": {
       "version": "6.10.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@decentralized-identity/ion-sdk": "0.5.0",
     "@transmute/did-key-bls12381": "^0.2.1-unstable.42",
     "@transmute/did-key-ed25519": "^0.2.1-unstable.42",
-    "@transmute/did-key-p384": "^0.2.1-unstable.20",
     "@transmute/did-key-secp256k1": "^0.2.1-unstable.42",
     "@transmute/did-key-x25519": "^0.2.1-unstable.42",
     "@transmute/did-key.js": "^0.2.1-unstable.42",
@@ -44,6 +43,8 @@
     "identity"
   ],
   "author": "Decentralized Identity Foundation",
-  "engines" : { "node" : ">=0.12" },
+  "engines": {
+    "node": ">=0.12"
+  },
   "engineStrict": true
 }


### PR DESCRIPTION
Removes the `@transmute/did-key-p384` dependency because:

- It is not in use in this repo
- It has been deprecated by transmute https://www.npmjs.com/package/@transmute/did-key-p384 
- Its causing issues while installing `ion-cli`