### PR TITLE
Browser Extension Compatibility

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,14 +12,14 @@ module.exports = {
       'error',
       'unix'
     ],
-    'curly': ['error', 'all'],
+    'curly': [ 'error', 'all' ],
     'quotes': [
       'error',
       'single',
       { 'allowTemplateLiterals': true }
     ],
-    'semi': ['error', 'always'],
-    'no-trailing-spaces': ['error'],
+    'semi': [ 'error', 'always' ],
+    'no-trailing-spaces': [ 'error' ],
     'no-unused-vars': [
       'error',
       {
@@ -29,6 +29,8 @@ module.exports = {
         'argsIgnorePattern': '^_',
         'varsIgnorePattern': '^_'
       }
-    ]
+    ],
+    'array-bracket-spacing': [ 'error', 'always' ],
+    'object-curly-spacing': [ 'error', 'always' ]
   }
 };

--- a/bundle.js
+++ b/bundle.js
@@ -1,12 +1,12 @@
 import esbuild from 'esbuild';
 
 esbuild.build({
-  entryPoints: ['./src/index.js'],
+  entryPoints: [ './src/index.js' ],
   bundle: true,
   format: 'esm',
   sourcemap: true,
   platform: 'browser',
-  target: ['chrome101'],
+  target: [ 'chrome101' ],
   define: {
     'global': 'globalThis'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decentralized-identity/ion-tools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@decentralized-identity/ion-tools",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "0.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@decentralized-identity/ion-tools",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@decentralized-identity/ion-tools",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@decentralized-identity/ion-sdk": "0.6.0",
@@ -636,6 +636,29 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1186,29 +1209,6 @@
         "hash-wasm": "4.4.1"
       }
     },
-    "node_modules/ion-pow-sdk/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "node_modules/ion-pow-sdk/node_modules/cross-fetch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.2.tgz",
@@ -1508,6 +1508,14 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1703,14 +1711,6 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uri-js/node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/varint": {
@@ -2106,6 +2106,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "callsites": {
@@ -2520,15 +2529,6 @@
         "hash-wasm": "4.4.1"
       },
       "dependencies": {
-        "buffer": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-          "requires": {
-            "base64-js": "^1.3.1",
-            "ieee754": "^1.2.1"
-          }
-        },
         "cross-fetch": {
           "version": "3.1.2",
           "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.2.tgz",
@@ -2749,6 +2749,11 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
     },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2870,13 +2875,6 @@
       "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
       "requires": {
         "punycode": "^2.1.0"
-      },
-      "dependencies": {
-        "punycode": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-        }
       }
     },
     "varint": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@decentralized-identity/ion-tools",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "ION Tools - utilities to make working with the ION network and using ION DIDs easy peasy lemon squeezy",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "./src/index.js": "./dist/browser-bundle.js"
   },
   "scripts": {
-    "bundle": "node ./bundle.js",
+    "bundle": "rm -rf ./dist && node ./bundle.js",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix"
   },

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "scripts": {
     "bundle": "rm -rf ./dist && node ./bundle.js",
+    "publish": "npm run bundle && npm publish",
     "lint": "eslint . --max-warnings 0",
     "lint:fix": "eslint . --fix"
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,4 @@
-import fetch from 'cross-fetch';
+import crossFetch from 'cross-fetch';
 import ProofOfWorkSDK from 'ion-pow-sdk';
 
 import * as ed25519 from '@noble/ed25519';
@@ -7,6 +7,14 @@ import * as secp256k1 from '@noble/secp256k1';
 import { base64url } from 'multiformats/bases/base64';
 import { IonKey } from '@decentralized-identity/ion-sdk';
 import { sha256 } from 'multiformats/hashes/sha2';
+
+// supports fetch in: node, browsers, and browser extensions.
+// uses native fetch if available in environment or falls back to a ponyfill.
+// 'cross-fetch' is a ponyfill that uses `XMLHTTPRequest` under the hood.
+// `XMLHTTPRequest` cannot be used in browser extension background service workers.
+// browser extensions get even more strict with `fetch` in that it cannot be referenced
+// indirectly.
+const fetch = globalThis.fetch ?? crossFetch;
 
 /**
  * @typedef {object} PrivateJWK

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,7 +139,7 @@ export async function verify(params = { }) {
       // create an uncompressed public key using the x and y values from the provided JWK.
       // a leading byte of 0x04 indicates that the public key is uncompressed
       // (e.g. x and y values are both present)
-      publicKeyBytes.set([0x04], 0);
+      publicKeyBytes.set([ 0x04 ], 0);
       publicKeyBytes.set(xBytes, 1);
       publicKeyBytes.set(yBytes, xBytes.length + 1);
 


### PR DESCRIPTION
# Summary
* Fixed an issue that was causing ION DID resolution and anchoring to bork in browser extensions.
    * `cross-fetch` is a [ponyfill](https://github.com/sindresorhus/ponyfill) that uses `XMLHTTPRequest` under the hood in browser environments. Unfortunately, `XMLHTTPRequest` cannot be used in MV3 browser extension background service workers. browser extensions get even more strict with `fetch` in that it cannot be referenced indirectly. 

Screenshot is a console in the context of a background service worker. Running `XMLHTTPRequestTest` shows that use of `XMLHTTPRequest` is not allowed. `IndirectReferenceTest` shows inability to use fetch when referenced indirectly

![image](https://user-images.githubusercontent.com/4887440/209607187-d55f42aa-6101-409b-862f-537759a88dce.png) 

* Fixed bugs introduced in `1.0.2`. @dcrousso, check out [this commit](https://github.com/decentralized-identity/ion-tools/commit/4b2f08a0cce364d636b2f67baffc8154f80f2bf4) for the fixes.  Manually tested using `examples/example.html`
* added `eslint` rules to match code style introduced in `1.0.2`