### PR TITLE
fix: store create operation as object in this.#ops

### DIFF
--- a/src/did.js
+++ b/src/did.js
@@ -10,7 +10,7 @@ export class DID {
   constructor(options = { }) {
     this.#ops = options.ops || [ ];
     if (!this.#ops.length) {
-      this.#ops.push(this.generateOperation('create', options.content || { }, false));
+      this.generateOperation('create', options.content || { }, true);
     }
   }
 
@@ -126,7 +126,7 @@ export class DID {
    *
    * // returns: EiCZws6U61LV3YmvxmOIlt4Ap5RSJdIkb_lJXhuUPqQYBg
    * did.getSuffix()
-   * @returns {string} suffix
+   * @returns {Promise<string>} suffix
    */
   async getSuffix() {
     const uri = await this.getURI('short');


### PR DESCRIPTION
fixes #49 @csuwildcat 

As explained there, the create operation was incorrectly stored as a Promise in the operation queue, leading to errors when trying to generate a request for a subsequent operation.
(The create operation was always stored as a Promise, but previously all the operations were awaited with Promise.all() in generateOperation, so that previous always was a pointer to the plain object. With the recent changes, this.#ops was accessed directly and no longer awaited, leading to the described problem. Storing the create operation as a promise is not necessarily incorrect - I just don't see a reason do it it like this while all other operations are stored as plain objects).

Consequently, it would not be necessary anymore for getAllOperations() to be async / use Promise.all(). Same for getOperation().

Is it planned to add tests to this library and/or to migrate to TypeScript? This would have caught the error.