### PR TITLE
Remove references to retired APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,10 +450,8 @@ The `anchor` function is used to submit an ION operation for anchoring with an I
 
 1. `REQUEST_BODY` - Object, *required*
 2. `OPTIONS` - Object, *optional*: An object for passing the following options used in the resolution request:
-    - `challengeEndpoint` - URI String, *optional*: URI of the challenge endpoint for the ION node you are submitting to.
-    - `solutionEndpoint` - URI String, *optional*: URI of the solution endpoint for the ION node you are submitting your completed challenge to.
-
-> NOTE: Endpoint URIs will default to `https://beta.ion.msidentity.com` if not supplied
+    - `challengeEndpoint` - URI String, *required*: URI of the challenge endpoint for the ION node you are submitting to.
+    - `solutionEndpoint` - URI String, *required*: URI of the solution endpoint for the ION node you are submitting your completed challenge to.
 
 ```javascript
 const did = new DID();

--- a/src/utils.js
+++ b/src/utils.js
@@ -183,8 +183,7 @@ export async function resolve(didUri, options = { }) {
 
 export async function anchor(anchorRequest, options = { }) {
   const {
-    challengeEndpoint = 'https://beta.ion.msidentity.com/api/v1.0/proof-of-work-challenge',
-    solutionEndpoint = 'https://beta.ion.msidentity.com/api/v1.0/operations'
+    challengeEndpoint, solutionEndpoint
   } = options;
 
   return ProofOfWorkSDK.submitIonRequest(challengeEndpoint, solutionEndpoint, JSON.stringify(anchorRequest));


### PR DESCRIPTION
The endpoints under `https://beta.ion.msidentity.com` are no longer available, so I propose removing references to them for the sake of clarity, c.f. https://github.com/decentralized-identity/ion-tools/issues/64